### PR TITLE
windows cmd script, process images in folder, print time elapsed, take on anyhow dep, crop images.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.75"
 image = "0.24.7"
 ndarray = "0.15.6"
 ort = "1.15.2"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-# rust-background-removal
+# 🦀 Background Removal
 
 ![Example](images/example.png)
+
+This Rust implementation is a minimal port of the original JavaScript library `@imgly/background-removal`. It aims to explore **the use of ONNX models in Rust** for background removal tasks. If you're interested in the full capabilities and details of the background removal process, I highly recommend checking out the original JavaScript library's [README](https://github.com/imgly/background-removal-js) here.
+
+## Usage
+
+```sh
+# Download all pretrained models
+./download_models.sh
+
+# Update variable input_img_file in src/main.rs
+
+# Run the program
+cargo run --release
+```
+
+## Related sites
+[pykeio/ort: A Rust wrapper for ONNX Runtime](https://github.com/pykeio/ort)
+
+## License
+
+[GNU GPLv3](https://choosealicense.com/licenses/gpl-3.0/)

--- a/download_models.cmd
+++ b/download_models.cmd
@@ -1,0 +1,4 @@
+mkdir -p "assets"
+curl -L "https://github.com/imgly/background-removal-js/raw/main/bundle/models/small" -o "assets/small.onnx"
+curl -L "https://github.com/imgly/background-removal-js/raw/main/bundle/models/medium" -o "assets/medium.onnx"
+curl -L "https://github.com/imgly/background-removal-js/raw/main/bundle/models/large" -o "assets/large.onnx"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,46 @@
 use image::imageops;
 use ndarray::{Array, CowArray};
 use ort::{
-    Environment, ExecutionProvider, GraphOptimizationLevel, OrtResult, SessionBuilder, Value,
+    Environment, ExecutionProvider, GraphOptimizationLevel, SessionBuilder, Value,
 };
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
+use anyhow::Result;
+use std::time::Instant; 
 
-fn main() -> OrtResult<()> {
-    // Input image file path
-    let input_img_file = Path::new("images/1.jpg");
+fn main() -> Result<()> {
+     // Input image file folder path
+    let input_images_folder = Path::new("images");
+    let output_images_folder = Path::new("output_images");
+    fs::create_dir_all(&output_images_folder)?;
 
-    // Output image file path is from the input image file path with "_nbg" suffix
-    let output_img_file = input_img_file
-        .with_file_name(format!(
-            "{}_nbg",
-            input_img_file.file_stem().unwrap().to_str().unwrap()
-        ))
-        .with_extension("png");
+    let image_files: Vec<PathBuf> = fs::read_dir(&input_images_folder)?
+        .filter_map(|entry| {
+            if let Ok(entry) = entry {
+                if let Some(extension) = entry.path().extension() {
+                    if extension == "jpg" || extension == "png" {
+                        return Some(entry.path());
+                    }
+                }
+            }
+            None
+        })
+        .collect();
 
+    for input_img_file in &image_files {
+    let output_img_file = output_images_folder
+        .join(
+            input_img_file
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_owned()
+                + "_nbg.png"
+        );
+
+    // Start timing
+    let start_time = Instant::now();
     // ONNX model file path
     let onnx_model_file = "assets/medium.onnx";
 
@@ -28,7 +52,7 @@ fn main() -> OrtResult<()> {
         .with_optimization_level(GraphOptimizationLevel::Level1)? // Configure model optimization level
         .with_intra_threads(1)? // Configure the number of threads used for inference
         .with_execution_providers([
-            // Configure execution providers (e.g., CUDA, CoreML, CPU)
+// Configure execution providers (e.g., CUDA, CoreML, CPU)
             ExecutionProvider::CUDA(Default::default()),
             ExecutionProvider::CoreML(Default::default()),
             ExecutionProvider::CPU(Default::default()),
@@ -36,66 +60,75 @@ fn main() -> OrtResult<()> {
         .with_model_from_file(onnx_model_file)?; // Load the ONNX model from a file
 
     // Get the required input shape: [batch_size, channel, height, width]
-    let input_shape = session.inputs[0]
-        .dimensions()
-        .map(|dim| dim.unwrap())
-        .collect::<Vec<usize>>();
+        let input_shape = session.inputs[0]
+            .dimensions()
+            .map(|dim| dim.unwrap())
+            .collect::<Vec<usize>>();
 
-    // Read and convert the input image to RGBA8 format
+            
+        // Read and convert the input image to RGBA8 format
     let input_img = image::open(input_img_file).unwrap().into_rgba8();
 
-    // Calculate the scaling factor for resizing
-    let scaling_factor = f32::min(
-        1., // Avoid upscaling
-        f32::min(
-            input_shape[3] as f32 / input_img.width() as f32, // Width ratio
-            input_shape[2] as f32 / input_img.height() as f32, // Height ratio
-        ),
-    );
+// Calculate the scaling factor for resizing
+        let scaling_factor = f32::min(
+            1., // Avoid upscaling
+            f32::min(
+                input_shape[3] as f32 / input_img.width() as f32, // Width ratio
+                input_shape[2] as f32 / input_img.height() as f32, // Height ratio
+            ),
+        );
 
-    // Resize the input image to match the model input shape
-    let mut resized_img = imageops::resize(
-        &input_img,
-        input_shape[3] as u32,
-        input_shape[2] as u32,
-        imageops::FilterType::Triangle,
-    );
+// Resize the input image to match the model input shape
+        let mut resized_img = imageops::resize(
+            &input_img,
+            input_shape[3] as u32,
+            input_shape[2] as u32,
+            imageops::FilterType::Triangle,
+        );
 
-    // Create an input tensor from the normalized input image
-    let input_tensor = CowArray::from(
-        Array::from_shape_fn(input_shape, |indices| {
-            let mean = 128.;
-            let std = 256.;
-
+// Create an input tensor from the normalized input image
+        let input_tensor = CowArray::from(
+            Array::from_shape_fn(input_shape, |indices| {
+                let mean = 128.;
+                let std = 256.;
+                
             (resized_img[(indices[3] as u32, indices[2] as u32)][indices[1]] as f32 - mean) / std
-        })
-        .into_dyn(),
-    );
+            })
+            .into_dyn(),
+        );
 
-    // Prepare an input batch for inference with a single instance
-    let inputs = vec![Value::from_array(session.allocator(), &input_tensor)?];
+// Prepare an input batch for inference with a single instance
+        let inputs = vec![Value::from_array(session.allocator(), &input_tensor)?];
 
     // Perform the inference
-    let outputs = session.run(inputs)?;
+        let outputs = session.run(inputs)?;
 
     // Extract the output tensor from the output batch
-    let output_tensor = outputs[0].try_extract::<f32>()?;
+        let output_tensor = outputs[0].try_extract::<f32>()?;
 
-    // Update the alpha channel of the resized image with the predicted values
-    for (indices, alpha) in output_tensor.view().indexed_iter() {
-        resized_img[(indices[3] as u32, indices[2] as u32)][3] = (alpha * 255.) as u8;
+// Update the alpha channel of the resized image with the predicted values
+        for (indices, alpha) in output_tensor.view().indexed_iter() {
+            resized_img[(indices[3] as u32, indices[2] as u32)][3] = (alpha * 255.) as u8;
+        }
+
+// Resize the final output image back to the original size if possible using the scaling factor
+        let output_img = imageops::resize(
+            &resized_img,
+            (input_img.width() as f32 * scaling_factor) as u32,
+            (input_img.height() as f32 * scaling_factor) as u32,
+            imageops::FilterType::Triangle,
+        );
+
+        output_img.save(output_img_file)?;
+		
+        let elapsed_time = start_time.elapsed();
+        println!(
+            "Processed {} in {}.{:03} seconds",
+            input_img_file.display(),
+            elapsed_time.as_secs(),
+            elapsed_time.subsec_millis()
+        );
     }
-
-    // Resize the final output image back to the original size if possible using the scaling factor
-    let output_img = imageops::resize(
-        &resized_img,
-        (input_img.width() as f32 * scaling_factor) as u32,
-        (input_img.height() as f32 * scaling_factor) as u32,
-        imageops::FilterType::Triangle,
-    );
-
-    // Save the final output image to the output image file path
-    output_img.save(output_img_file).unwrap();
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,13 @@
-use image::{imageops,RgbaImage, Rgba, ImageBuffer, GenericImage};
+use anyhow::Result;
+use image::{imageops, GenericImage, ImageBuffer, RgbaImage};
 use ndarray::{Array, CowArray};
-use ort::{
-    Environment, ExecutionProvider, GraphOptimizationLevel, SessionBuilder, Value,
-};
+use ort::{Environment, ExecutionProvider, GraphOptimizationLevel, SessionBuilder, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
-use anyhow::Result;
-use std::time::Instant; 
+use std::time::Instant;
 
 fn main() -> Result<()> {
-     // Input image file folder path
+    // Input image file folder path
     let input_images_folder = Path::new("images");
     let output_images_folder = Path::new("output_images");
     fs::create_dir_all(&output_images_folder)?;
@@ -28,48 +26,46 @@ fn main() -> Result<()> {
         .collect();
 
     for input_img_file in &image_files {
-    let output_img_file = output_images_folder
-        .join(
+        let output_img_file = output_images_folder.join(
             input_img_file
                 .file_stem()
                 .unwrap()
                 .to_str()
                 .unwrap()
                 .to_owned()
-                + "_nbg.png"
+                + "_nbg.png",
         );
 
-    // Start timing
-    let start_time = Instant::now();
-    // ONNX model file path
-    let onnx_model_file = "assets/medium.onnx";
+        // Start timing
+        let start_time = Instant::now();
+        // ONNX model file path
+        let onnx_model_file = "assets/medium.onnx";
 
-    // Create an Ort environment, which manages resources for ONNX Runtime
-    let environment = Environment::default().into_arc();
+        // Create an Ort environment, which manages resources for ONNX Runtime
+        let environment = Environment::default().into_arc();
 
-    // Create an Ort session for inference using the provided ONNX model
-    let session = SessionBuilder::new(&environment)?
-        .with_optimization_level(GraphOptimizationLevel::Level1)? // Configure model optimization level
-        .with_intra_threads(1)? // Configure the number of threads used for inference
-        .with_execution_providers([
-// Configure execution providers (e.g., CUDA, CoreML, CPU)
-            ExecutionProvider::CUDA(Default::default()),
-            ExecutionProvider::CoreML(Default::default()),
-            ExecutionProvider::CPU(Default::default()),
-        ])?
-        .with_model_from_file(onnx_model_file)?; // Load the ONNX model from a file
+        // Create an Ort session for inference using the provided ONNX model
+        let session = SessionBuilder::new(&environment)?
+            .with_optimization_level(GraphOptimizationLevel::Level1)? // Configure model optimization level
+            .with_intra_threads(1)? // Configure the number of threads used for inference
+            .with_execution_providers([
+                // Configure execution providers (e.g., CUDA, CoreML, CPU)
+                ExecutionProvider::CUDA(Default::default()),
+                ExecutionProvider::CoreML(Default::default()),
+                ExecutionProvider::CPU(Default::default()),
+            ])?
+            .with_model_from_file(onnx_model_file)?; // Load the ONNX model from a file
 
-    // Get the required input shape: [batch_size, channel, height, width]
+        // Get the required input shape: [batch_size, channel, height, width]
         let input_shape = session.inputs[0]
             .dimensions()
             .map(|dim| dim.unwrap())
             .collect::<Vec<usize>>();
 
-            
         // Read and convert the input image to RGBA8 format
-    let input_img = image::open(input_img_file).unwrap().into_rgba8();
+        let input_img = image::open(input_img_file).unwrap().into_rgba8();
 
-// Calculate the scaling factor for resizing
+        // Calculate the scaling factor for resizing
         let scaling_factor = f32::min(
             1., // Avoid upscaling
             f32::min(
@@ -78,7 +74,7 @@ fn main() -> Result<()> {
             ),
         );
 
-// Resize the input image to match the model input shape
+        // Resize the input image to match the model input shape
         let mut resized_img = imageops::resize(
             &input_img,
             input_shape[3] as u32,
@@ -86,32 +82,33 @@ fn main() -> Result<()> {
             imageops::FilterType::Triangle,
         );
 
-// Create an input tensor from the normalized input image
+        // Create an input tensor from the normalized input image
         let input_tensor = CowArray::from(
             Array::from_shape_fn(input_shape, |indices| {
                 let mean = 128.;
                 let std = 256.;
-                
-            (resized_img[(indices[3] as u32, indices[2] as u32)][indices[1]] as f32 - mean) / std
+
+                (resized_img[(indices[3] as u32, indices[2] as u32)][indices[1]] as f32 - mean)
+                    / std
             })
             .into_dyn(),
         );
 
-// Prepare an input batch for inference with a single instance
+        // Prepare an input batch for inference with a single instance
         let inputs = vec![Value::from_array(session.allocator(), &input_tensor)?];
 
-    // Perform the inference
+        // Perform the inference
         let outputs = session.run(inputs)?;
 
-    // Extract the output tensor from the output batch
+        // Extract the output tensor from the output batch
         let output_tensor = outputs[0].try_extract::<f32>()?;
 
-// Update the alpha channel of the resized image with the predicted values
+        // Update the alpha channel of the resized image with the predicted values
         for (indices, alpha) in output_tensor.view().indexed_iter() {
             resized_img[(indices[3] as u32, indices[2] as u32)][3] = (alpha * 255.) as u8;
         }
 
-// Resize the final output image back to the original size if possible using the scaling factor
+        // Resize the final output image back to the original size if possible using the scaling factor
         let mut output_img = imageops::resize(
             &resized_img,
             (input_img.width() as f32 * scaling_factor) as u32,
@@ -120,7 +117,7 @@ fn main() -> Result<()> {
         );
 
         output_img.save(&output_img_file)?;
-		
+
         let elapsed_time = start_time.elapsed();
         println!(
             "Processed {} in {}.{:03} seconds",
@@ -131,28 +128,29 @@ fn main() -> Result<()> {
         let alpha_bounds = find_alpha_bounds(&output_img);
 
         if let Some((min_x, min_y, max_x, max_y)) = alpha_bounds {
-            let cropped_img = imageops::crop(&mut output_img, min_x, min_y, max_x - min_x, max_y - min_y).to_image();
-    // Convert the cropped image to a full image
-    let mut full_cropped_img = ImageBuffer::new(max_x - min_x, max_y - min_y);
-    full_cropped_img.copy_from(&cropped_img, 0, 0);
+            let cropped_img =
+                imageops::crop(&mut output_img, min_x, min_y, max_x - min_x, max_y - min_y)
+                    .to_image();
+            // Convert the cropped image to a full image
+            let mut full_cropped_img = ImageBuffer::new(max_x - min_x, max_y - min_y);
+            full_cropped_img.copy_from(&cropped_img, 0, 0).ok();
 
-        // Modify the output file path to include "_cropped" before the extension
-        let mut output_img_file_cropped = output_img_file.clone();
-        if let Some(extension) = output_img_file_cropped.extension() {
-            let file_stem = output_img_file_cropped.file_stem().unwrap();
-            let new_file_stem = format!("{}_cropped", file_stem.to_str().unwrap());
-            output_img_file_cropped.set_file_name(new_file_stem);
-        }
-    
-        // Append the original extension to the modified output file path
-        if let Some(extension) = output_img_file.extension() {
-            output_img_file_cropped.set_extension(extension);
-        }
+            // Modify the output file path to include "_cropped" before the extension
+            let mut output_img_file_cropped = output_img_file.clone();
+            if let Some(_extension) = output_img_file_cropped.extension() {
+                let file_stem = output_img_file_cropped.file_stem().unwrap();
+                let new_file_stem = format!("{}_cropped", file_stem.to_str().unwrap());
+                output_img_file_cropped.set_file_name(new_file_stem);
+            }
 
-    // Save the cropped image
-    full_cropped_img.save(output_img_file_cropped)?;
-        }
+            // Append the original extension to the modified output file path
+            if let Some(extension) = output_img_file.extension() {
+                output_img_file_cropped.set_extension(extension);
+            }
 
+            // Save the cropped image
+            full_cropped_img.save(output_img_file_cropped)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
windows doesn't like ' using " in the original script would be enough to make it work as another solution.  creating a .cmd file works too.

```
warning: `rust-background-removal` (bin "rust-background-removal") generated 1 warning (run `cargo fix --bin "rust-background-removal"` to apply 1 suggestion)
    Finished release [optimized] target(s) in 22.17s
     Running `target\release\rust-background-removal.exe`
Processed images\1409.jpg in 54.581 seconds
Processed images\1418.jpg in 53.612 seconds
Processed images\1419.jpg in 59.436 seconds
Processed images\1422.jpg in 60.051 seconds
Processed images\1426.jpg in 62.424 seconds
error: process didn't exit successfully: `target\release\rust-background-removal.exe` (exit code: 0xc000013a, STATUS_CONTROL_C_EXIT)
^C
c:\working\rust\rust-background-removal>cargo run --release
   Compiling rust-background-removal v0.1.0 (C:\working\rust\rust-background-removal)
    Finished release [optimized] target(s) in 15.14s
     Running `target\release\rust-background-removal.exe`
Processed images\1409.jpg in 43.106 seconds
Processed images\1418.jpg in 45.201 seconds
Processed images\1419.jpg in 44.536 seconds
Processed images\1422.jpg in 43.536 seconds
Processed images\1426.jpg in 44.610 seconds
error: process didn't exit successfully: `target\release\rust-background-removal.exe` (exit code: 0xc000013a, STATUS_CONTROL_C_EXIT)
^C
c:\working\rust\rust-background-removal>cargo run --release
    Blocking waiting for file lock on package cache
   Compiling rust-background-removal v0.1.0 (C:\working\rust\rust-background-removal)
    Finished release [optimized] target(s) in 17.60s
     Running `target\release\rust-background-removal.exe`
Processed images\1409.jpg in 42.096 seconds
Processed images\1418.jpg in 40.025 seconds
Processed images\1419.jpg in 46.536 seconds
Processed images\1422.jpg in 40.420 seconds
error: process didn't exit successfully: `target\release\rust-background-removal.exe` (exit code: 0xc000013a, STATUS_CONTROL_C_EXIT)
```
I was surprised that small (shown first, medium, then large), was slowest of the models and it was faster as the size of the model went up!  Idk if you want to take on anyhow, a dyn Error could is another solution.

I didn't see much to read on theory of operation from imgly/background-removal-js.  The online demo did not work for me.

Your code did, thanks for the code.